### PR TITLE
make the iOS version build with fake ncurses headers, but real protobuf compile artifacts

### DIFF
--- a/build-mosh.sh
+++ b/build-mosh.sh
@@ -39,7 +39,7 @@ buildit()
 
     export CC="$(xcrun -sdk iphoneos -find clang)"
     export CPP="$CC -E"
-    export CFLAGS="-arch ${target} -isysroot $PLATFORMPATH/$platform.platform/Developer/SDKs/$platform$SDKVERSION.sdk -miphoneos-version-min=$SDKVERSION"
+    export CFLAGS="-arch ${target} -isysroot $PLATFORMPATH/$platform.platform/Developer/SDKs/$platform$SDKVERSION.sdk -miphoneos-version-min=$SDKVERSION -I$pwd/headers"
     export AR=$(xcrun -sdk iphoneos -find ar)
     export RANLIB=$(xcrun -sdk iphoneos -find ranlib)
     export CPPFLAGS="-arch ${target}  -isysroot $PLATFORMPATH/$platform.platform/Developer/SDKs/$platform$SDKVERSION.sdk -miphoneos-version-min=$SDKVERSION"
@@ -64,9 +64,16 @@ buildit()
 
 findLatestSDKVersion iPhoneOS
 
-buildit arm64 iPhoneOS
+mkdir headers
+cd headers
+for i in ncurses.h ncurses_dll.h unctrl.h curses.h term.h ; do
+ln -s /usr/include/$i .
+done
+cd ..
+
 buildit i386 iPhoneSimulator
 buildit x86_64 iPhoneSimulator
+buildit arm64 iPhoneOS
 
 LIPO=$(xcrun -sdk iphoneos -find lipo)
 $LIPO -create $pwd/output/x86_64/libmoshcrypto.a $pwd/output/i386/libmoshcrypto.a $pwd/output/arm64/libmoshcrypto.a  -output $pwd/output/libmoshcrypto.a

--- a/build-mosh.sh
+++ b/build-mosh.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+PROTOBUFDIR=`cd ../build-protobuf; pwd`
 PLATFORMPATH="/Applications/Xcode.app/Contents/Developer/Platforms"
 TOOLSPATH="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin"
 export IPHONEOS_DEPLOYMENT_TARGET="8.0"
@@ -37,12 +38,13 @@ buildit()
 	hosttarget="arm"
     fi
 
+    export ac_cv_path_PROTOC="$PROTOBUFDIR/protobuf-2.6.1/bin/protoc"
     export CC="$(xcrun -sdk iphoneos -find clang)"
     export CPP="$CC -E"
-    export CFLAGS="-arch ${target} -isysroot $PLATFORMPATH/$platform.platform/Developer/SDKs/$platform$SDKVERSION.sdk -miphoneos-version-min=$SDKVERSION -I$pwd/headers"
+    export CFLAGS="-arch ${target} -isysroot $PLATFORMPATH/$platform.platform/Developer/SDKs/$platform$SDKVERSION.sdk -miphoneos-version-min=$SDKVERSION -I$pwd/headers -I$PROTOBUFDIR/protobuf-2.6.1/include"
     export AR=$(xcrun -sdk iphoneos -find ar)
     export RANLIB=$(xcrun -sdk iphoneos -find ranlib)
-    export CPPFLAGS="-arch ${target}  -isysroot $PLATFORMPATH/$platform.platform/Developer/SDKs/$platform$SDKVERSION.sdk -miphoneos-version-min=$SDKVERSION"
+    export CPPFLAGS="-arch ${target}  -isysroot $PLATFORMPATH/$platform.platform/Developer/SDKs/$platform$SDKVERSION.sdk -miphoneos-version-min=$SDKVERSION -I$PROTOBUFDIR/protobuf-2.6.1/include"
     export LDFLAGS="-arch ${target} -isysroot $PLATFORMPATH/$platform.platform/Developer/SDKs/$platform$SDKVERSION.sdk"
 
     mkdir -p $pwd/output/$target


### PR DESCRIPTION
iOS includes ncurses library but not headers. cheat and use the host (macos) headers. 

also, ignore any system protobuf and use the one compiled for this
